### PR TITLE
Update Supabase CLI install steps in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,8 +20,9 @@ jobs:
       - name: Install Supabase CLI
         run: |
           curl -o supabase.tar.gz -L https://github.com/supabase/cli/releases/latest/download/supabase_linux_amd64.tar.gz
-          tar -xzf supabase.tar.gz
-          sudo mv supabase /usr/local/bin/
+          tar -xzf supabase.tar.gz --strip-components=1
+          sudo mv supabase /usr/local/bin/supabase
+          rm -f supabase.tar.gz
           supabase --version
         # Installs Supabase CLI globally
       - name: Run Supabase migrations (QA)
@@ -44,8 +45,9 @@ jobs:
       - name: Install Supabase CLI
         run: |
           curl -o supabase.tar.gz -L https://github.com/supabase/cli/releases/latest/download/supabase_linux_amd64.tar.gz
-          tar -xzf supabase.tar.gz
-          sudo mv supabase /usr/local/bin/
+          tar -xzf supabase.tar.gz --strip-components=1
+          sudo mv supabase /usr/local/bin/supabase
+          rm -f supabase.tar.gz
           supabase --version
         # Installs Supabase CLI globally
       - name: Run Supabase migrations (PROD)


### PR DESCRIPTION
Adds --strip-components=1 to tar extraction, specifies destination filename for mv, and removes the downloaded archive after installation. This streamlines the Supabase CLI installation process in both QA and PROD jobs.